### PR TITLE
Removed UltraMagicString implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,41 +13,14 @@ def get_version(package):
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
-class UltraMagicString(object):
-    '''
-    Taken from
-    http://stackoverflow.com/questions/1162338/whats-the-right-way-to-use-unicode-metadata-in-setup-py
-    '''
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        return self.value
-
-    def __unicode__(self):
-        return self.value.decode('UTF-8')
-
-    def __add__(self, other):
-        return UltraMagicString(self.value + str(other))
-
-    def split(self, *args, **kw):
-        return self.value.split(*args, **kw)
-
-
-long_description = UltraMagicString(u'\n\n'.join((
-    open('README.rst').read(),
-    open('CHANGES.rst').read(),
-)))
-
-
 setup(
     name = 'django-autofixture',
     version = get_version('autofixture'),
     url = 'https://github.com/gregmuellegger/django-autofixture',
     license = 'BSD',
     description = 'Provides tools to auto generate test data.',
-    long_description = long_description,
-    author = UltraMagicString('Gregor Müllegger'),
+    long_description = '',
+    author = 'Gregor Müllegger',
     author_email = 'gregor@muellegger.de',
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hij loopt tegen setup crashes aan omdat UltraMagicString geen `endswith` heeft, maar die hele implementatie is een fix voor iets wat al lang gefixt is.