### PR TITLE
Removed providing_args from signal

### DIFF
--- a/autofixture/signals.py
+++ b/autofixture/signals.py
@@ -2,4 +2,4 @@
 from django.dispatch import Signal
 
 
-instance_created = Signal(providing_args=['model', 'instance', 'committed'])
+instance_created = Signal()


### PR DESCRIPTION
https://github.com/django/django/blob/3.2.25/django/dispatch/dispatcher.py
![image](https://github.com/denniseijpe/django-autofixture/assets/31250247/77fdc2a7-74c8-4b48-ae44-4d869346a2cc)

Has been removed in Django 4.0.